### PR TITLE
Additional Property Support: required, format, pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Indicate a string's "format" to be "email" if `@Email` is present
+- Option for returning "idn-email" instead of "email" as "format" if `@Email` is present
 - Indicate a string's "pattern" according to regular expressions on `@Pattern` or `@Email` (ignoring specified flags)
 - Option for enabling the inclusion of "pattern" expressions (they are excluded by default)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Option for treating not-nullable fields as "required" in their parent type
+- Option for treating not-nullable methods as "required" in their parent type
 - Indicate a string's "format" to be "email" if `@Email` is present
 - Option for returning "idn-email" instead of "email" as "format" if `@Email` is present
 - Indicate a string's "pattern" according to regular expressions on `@Pattern` or `@Email` (ignoring specified flags)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Indicate a string's "pattern" according to regular expressions on `@Pattern` or `@Email` (ignoring specified flags)
+- Option for enabling the inclusion of "pattern" expressions (they are excluded by default)
 
 ## [3.0.0] – 2019-06-10
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.github.victools</groupId>
     <artifactId>jsonschema-module-javax-validation</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -58,7 +58,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <version.generator>3.0.0</version.generator>
+        <version.generator>3.2.0-SNAPSHOT</version.generator>
 
         <version.javax.validation>2.0.1.Final</version.javax.validation>
         <version.junit>4.12</version.junit>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <version.generator>3.2.0-SNAPSHOT</version.generator>
+        <version.generator>3.2.0</version.generator>
 
         <version.javax.validation>2.0.1.Final</version.javax.validation>
         <version.junit>4.12</version.junit>

--- a/src/main/java/com/github/victools/jsonschema/module/javax/validation/JavaxValidationOption.java
+++ b/src/main/java/com/github/victools/jsonschema/module/javax/validation/JavaxValidationOption.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.module.javax.validation;
+
+/**
+ * Flags to enable/disable certain aspects of the {@link JavaxValidationModule}'s processing.
+ */
+public enum JavaxValidationOption {
+    /**
+     * Use this option to include a string's "pattern" according to {@code @Pattern(regexp = "...")} or {@code @Email(regexp = "...")}.
+     */
+    INCLUDE_PATTERN_EXPRESSIONS;
+
+}

--- a/src/main/java/com/github/victools/jsonschema/module/javax/validation/JavaxValidationOption.java
+++ b/src/main/java/com/github/victools/jsonschema/module/javax/validation/JavaxValidationOption.java
@@ -21,6 +21,14 @@ package com.github.victools.jsonschema.module.javax.validation;
  */
 public enum JavaxValidationOption {
     /**
+     * Use this option to add not-nullable fields to their parent's list of "required" properties.
+     */
+    NOT_NULLABLE_FIELD_IS_REQUIRED,
+    /**
+     * Use this option to add not-nullable methods to their parent's list of "required" properties.
+     */
+    NOT_NULLABLE_METHOD_IS_REQUIRED,
+    /**
      * Use this option to indicate the "idn-email" format instead of "email" when an {@code @Email} annotation is being found.
      */
     PREFER_IDN_EMAIL_FORMAT,

--- a/src/main/java/com/github/victools/jsonschema/module/javax/validation/JavaxValidationOption.java
+++ b/src/main/java/com/github/victools/jsonschema/module/javax/validation/JavaxValidationOption.java
@@ -21,6 +21,10 @@ package com.github.victools.jsonschema.module.javax.validation;
  */
 public enum JavaxValidationOption {
     /**
+     * Use this option to indicate the "idn-email" format instead of "email" when an {@code @Email} annotation is being found.
+     */
+    PREFER_IDN_EMAIL_FORMAT,
+    /**
      * Use this option to include a string's "pattern" according to {@code @Pattern(regexp = "...")} or {@code @Email(regexp = "...")}.
      */
     INCLUDE_PATTERN_EXPRESSIONS;


### PR DESCRIPTION
Adding support for three new properties:
- "required" includes all fields/methods explicitly declared as not-nullable (if options are enabled)
- "format" supports "email"/"idn-email" in case of an `@Email` annotation being present (as per https://github.com/victools/jsonschema-generator/issues/8)
- "pattern" supports regular expressions from `@Pattern` and `@Email` annotations (as per https://github.com/victools/jsonschema-generator/issues/9)

The support for "required" and "pattern" properties are only being introduced in `jsonschema-generator` version 3.2.0.
Therefore skipping version 3.1.0 of this library to be in-line with the main generator library's version number: 3.2.0.