### PR TITLE
Support javax.validation groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Option for returning "idn-email" instead of "email" as "format" if `@Email` is present
 - Indicate a string's "pattern" according to regular expressions on `@Pattern` or `@Email` (ignoring specified flags)
 - Option for enabling the inclusion of "pattern" expressions (they are excluded by default)
+- Allow filtering applicable annotations by their declared validation `groups` via `JavaxValidationModule.forValidationGroups()`
 
 ## [3.0.0] – 2019-06-10
 ### Added

--- a/src/main/java/com/github/victools/jsonschema/module/javax/validation/JavaxValidationModule.java
+++ b/src/main/java/com/github/victools/jsonschema/module/javax/validation/JavaxValidationModule.java
@@ -26,7 +26,9 @@ import java.lang.annotation.Annotation;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Email;
@@ -56,7 +58,8 @@ import javax.validation.constraints.Size;
  */
 public class JavaxValidationModule implements Module {
 
-    private final List<JavaxValidationOption> options;
+    private final Set<JavaxValidationOption> options;
+    private Set<Class<?>> validationGroups;
 
     /**
      * Constructor.
@@ -64,7 +67,29 @@ public class JavaxValidationModule implements Module {
      * @param options features to enable
      */
     public JavaxValidationModule(JavaxValidationOption... options) {
-        this.options = options == null ? Collections.emptyList() : Arrays.asList(options);
+        this.options = options == null ? Collections.emptySet() : new HashSet<>(Arrays.asList(options));
+        // by default: ignore validation groups
+        this.validationGroups = null;
+    }
+
+    /**
+     * Add validation groups to be considered.
+     * <ul>
+     * <li>Never calling this method will result in all annotations to be picked-up.</li>
+     * <li>Calling this without parameters will only consider those annotations where no groups are defined.</li>
+     * <li>Calling this with not-null parameters will only consider those annotations without defined groups or where at least one matches.</li>
+     * </ul>
+     *
+     * @param validationGroups validation groups to consider
+     * @return this module instance (for chaining)
+     */
+    public JavaxValidationModule forValidationGroups(Class<?>... validationGroups) {
+        if (validationGroups == null) {
+            this.validationGroups = null;
+        } else {
+            this.validationGroups = new HashSet<>(Arrays.asList(validationGroups));
+        }
+        return this;
     }
 
     @Override
@@ -110,12 +135,14 @@ public class JavaxValidationModule implements Module {
      * @param <A> type of annotation
      * @param member field or method to retrieve annotation instance from (or from a field's getter or getter method's field)
      * @param annotationClass type of annotation
+     * @param validationGroupsLookup how to look-up the associated validation groups of an annotation instance
      * @return annotation instance (or {@code null})
      * @see MemberScope#getAnnotation(Class)
      * @see FieldScope#findGetter()
      * @see MethodScope#findGetterField()
      */
-    protected <A extends Annotation> A getAnnotationFromFieldOrGetter(MemberScope<?, ?> member, Class<A> annotationClass) {
+    protected <A extends Annotation> A getAnnotationFromFieldOrGetter(MemberScope<?, ?> member, Class<A> annotationClass,
+            Function<A, Class<?>[]> validationGroupsLookup) {
         A annotation = member.getAnnotation(annotationClass);
         if (annotation == null) {
             MemberScope<?, ?> associatedGetterOrField;
@@ -128,6 +155,20 @@ public class JavaxValidationModule implements Module {
             }
             annotation = associatedGetterOrField == null ? null : associatedGetterOrField.getAnnotation(annotationClass);
         }
+        if (annotation != null) {
+            Class<?>[] associatedGroups = validationGroupsLookup.apply(annotation);
+            /*
+             * the annotation is deemed applicable in one of the following three cases:
+             * 1. Validation groups are specifically ignored (i.e. forValidationGroups() was never called or with null as only parameter)
+             * 2. No validation groups are specified on the annotation.
+             * 3. Some validation group(s) are specified on the annotation and at least one of them was provided via forValidationGroups().
+             */
+            if (this.validationGroups != null && associatedGroups.length > 0
+                    && Collections.disjoint(this.validationGroups, Arrays.asList(associatedGroups))) {
+                // ignore the looked-up annotation as it is not associated with one of the desired validation groups
+                annotation = null;
+            }
+        }
         return annotation;
     }
 
@@ -139,12 +180,12 @@ public class JavaxValidationModule implements Module {
      */
     protected Boolean isNullable(MemberScope<?, ?> member) {
         Boolean result;
-        if (this.getAnnotationFromFieldOrGetter(member, NotNull.class) != null
-                || this.getAnnotationFromFieldOrGetter(member, NotBlank.class) != null
-                || this.getAnnotationFromFieldOrGetter(member, NotEmpty.class) != null) {
+        if (this.getAnnotationFromFieldOrGetter(member, NotNull.class, NotNull::groups) != null
+                || this.getAnnotationFromFieldOrGetter(member, NotBlank.class, NotBlank::groups) != null
+                || this.getAnnotationFromFieldOrGetter(member, NotEmpty.class, NotEmpty::groups) != null) {
             // field is specifically NOT nullable
             result = Boolean.FALSE;
-        } else if (this.getAnnotationFromFieldOrGetter(member, Null.class) != null) {
+        } else if (this.getAnnotationFromFieldOrGetter(member, Null.class, Null::groups) != null) {
             // field is specifically null (and thereby nullable)
             result = Boolean.TRUE;
         } else {
@@ -173,12 +214,12 @@ public class JavaxValidationModule implements Module {
      */
     protected Integer resolveArrayMinItems(MemberScope<?, ?> member) {
         if (member.isContainerType()) {
-            Size sizeAnnotation = this.getAnnotationFromFieldOrGetter(member, Size.class);
+            Size sizeAnnotation = this.getAnnotationFromFieldOrGetter(member, Size.class, Size::groups);
             if (sizeAnnotation != null && sizeAnnotation.min() > 0) {
                 // minimum length greater than the default 0 was specified
                 return sizeAnnotation.min();
             }
-            if (this.getAnnotationFromFieldOrGetter(member, NotEmpty.class) != null) {
+            if (this.getAnnotationFromFieldOrGetter(member, NotEmpty.class, NotEmpty::groups) != null) {
                 return 1;
             }
         }
@@ -194,7 +235,7 @@ public class JavaxValidationModule implements Module {
      */
     protected Integer resolveArrayMaxItems(MemberScope<?, ?> member) {
         if (member.isContainerType()) {
-            Size sizeAnnotation = this.getAnnotationFromFieldOrGetter(member, Size.class);
+            Size sizeAnnotation = this.getAnnotationFromFieldOrGetter(member, Size.class, Size::groups);
             if (sizeAnnotation != null && sizeAnnotation.max() < 2147483647) {
                 // maximum length below the default 2147483647 was specified
                 return sizeAnnotation.max();
@@ -214,13 +255,13 @@ public class JavaxValidationModule implements Module {
      */
     protected Integer resolveStringMinLength(MemberScope<?, ?> member) {
         if (member.getType().isInstanceOf(CharSequence.class)) {
-            Size sizeAnnotation = this.getAnnotationFromFieldOrGetter(member, Size.class);
+            Size sizeAnnotation = this.getAnnotationFromFieldOrGetter(member, Size.class, Size::groups);
             if (sizeAnnotation != null && sizeAnnotation.min() > 0) {
                 // minimum length greater than the default 0 was specified
                 return sizeAnnotation.min();
             }
-            if (this.getAnnotationFromFieldOrGetter(member, NotEmpty.class) != null
-                    || this.getAnnotationFromFieldOrGetter(member, NotBlank.class) != null) {
+            if (this.getAnnotationFromFieldOrGetter(member, NotEmpty.class, NotEmpty::groups) != null
+                    || this.getAnnotationFromFieldOrGetter(member, NotBlank.class, NotBlank::groups) != null) {
                 return 1;
             }
         }
@@ -236,7 +277,7 @@ public class JavaxValidationModule implements Module {
      */
     protected Integer resolveStringMaxLength(MemberScope<?, ?> member) {
         if (member.getType().isInstanceOf(CharSequence.class)) {
-            Size sizeAnnotation = this.getAnnotationFromFieldOrGetter(member, Size.class);
+            Size sizeAnnotation = this.getAnnotationFromFieldOrGetter(member, Size.class, Size::groups);
             if (sizeAnnotation != null && sizeAnnotation.max() < 2147483647) {
                 // maximum length below the default 2147483647 was specified
                 return sizeAnnotation.max();
@@ -254,7 +295,7 @@ public class JavaxValidationModule implements Module {
      */
     protected String resolveStringFormat(MemberScope<?, ?> member) {
         if (member.getType().isInstanceOf(CharSequence.class)) {
-            Email emailAnnotation = this.getAnnotationFromFieldOrGetter(member, Email.class);
+            Email emailAnnotation = this.getAnnotationFromFieldOrGetter(member, Email.class, Email::groups);
             if (emailAnnotation != null) {
                 // @Email annotation was found, indicate the respective format
                 if (this.options.contains(JavaxValidationOption.PREFER_IDN_EMAIL_FORMAT)) {
@@ -277,12 +318,12 @@ public class JavaxValidationModule implements Module {
      */
     protected String resolveStringPattern(MemberScope<?, ?> member) {
         if (member.getType().isInstanceOf(CharSequence.class)) {
-            Pattern patternAnnotation = this.getAnnotationFromFieldOrGetter(member, Pattern.class);
+            Pattern patternAnnotation = this.getAnnotationFromFieldOrGetter(member, Pattern.class, Pattern::groups);
             if (patternAnnotation != null) {
                 // @Pattern annotation was found, return its (mandatory) regular expression
                 return patternAnnotation.regexp();
             }
-            Email emailAnnotation = this.getAnnotationFromFieldOrGetter(member, Email.class);
+            Email emailAnnotation = this.getAnnotationFromFieldOrGetter(member, Email.class, Email::groups);
             if (emailAnnotation != null && !".*".equals(emailAnnotation.regexp())) {
                 // non-default regular expression on @Email annotation should also be considered
                 return emailAnnotation.regexp();
@@ -301,15 +342,15 @@ public class JavaxValidationModule implements Module {
      * @see PositiveOrZero
      */
     protected BigDecimal resolveNumberInclusiveMinimum(MemberScope<?, ?> member) {
-        Min minAnnotation = this.getAnnotationFromFieldOrGetter(member, Min.class);
+        Min minAnnotation = this.getAnnotationFromFieldOrGetter(member, Min.class, Min::groups);
         if (minAnnotation != null) {
             return new BigDecimal(minAnnotation.value());
         }
-        DecimalMin decimalMinAnnotation = this.getAnnotationFromFieldOrGetter(member, DecimalMin.class);
+        DecimalMin decimalMinAnnotation = this.getAnnotationFromFieldOrGetter(member, DecimalMin.class, DecimalMin::groups);
         if (decimalMinAnnotation != null && decimalMinAnnotation.inclusive()) {
             return new BigDecimal(decimalMinAnnotation.value());
         }
-        PositiveOrZero positiveAnnotation = this.getAnnotationFromFieldOrGetter(member, PositiveOrZero.class);
+        PositiveOrZero positiveAnnotation = this.getAnnotationFromFieldOrGetter(member, PositiveOrZero.class, PositiveOrZero::groups);
         if (positiveAnnotation != null) {
             return BigDecimal.ZERO;
         }
@@ -325,11 +366,11 @@ public class JavaxValidationModule implements Module {
      * @see Positive
      */
     protected BigDecimal resolveNumberExclusiveMinimum(MemberScope<?, ?> member) {
-        DecimalMin decimalMinAnnotation = this.getAnnotationFromFieldOrGetter(member, DecimalMin.class);
+        DecimalMin decimalMinAnnotation = this.getAnnotationFromFieldOrGetter(member, DecimalMin.class, DecimalMin::groups);
         if (decimalMinAnnotation != null && !decimalMinAnnotation.inclusive()) {
             return new BigDecimal(decimalMinAnnotation.value());
         }
-        Positive positiveAnnotation = this.getAnnotationFromFieldOrGetter(member, Positive.class);
+        Positive positiveAnnotation = this.getAnnotationFromFieldOrGetter(member, Positive.class, Positive::groups);
         if (positiveAnnotation != null) {
             return BigDecimal.ZERO;
         }
@@ -346,15 +387,15 @@ public class JavaxValidationModule implements Module {
      * @see NegativeOrZero
      */
     protected BigDecimal resolveNumberInclusiveMaximum(MemberScope<?, ?> member) {
-        Max maxAnnotation = this.getAnnotationFromFieldOrGetter(member, Max.class);
+        Max maxAnnotation = this.getAnnotationFromFieldOrGetter(member, Max.class, Max::groups);
         if (maxAnnotation != null) {
             return new BigDecimal(maxAnnotation.value());
         }
-        DecimalMax decimalMaxAnnotation = this.getAnnotationFromFieldOrGetter(member, DecimalMax.class);
+        DecimalMax decimalMaxAnnotation = this.getAnnotationFromFieldOrGetter(member, DecimalMax.class, DecimalMax::groups);
         if (decimalMaxAnnotation != null && decimalMaxAnnotation.inclusive()) {
             return new BigDecimal(decimalMaxAnnotation.value());
         }
-        NegativeOrZero negativeAnnotation = this.getAnnotationFromFieldOrGetter(member, NegativeOrZero.class);
+        NegativeOrZero negativeAnnotation = this.getAnnotationFromFieldOrGetter(member, NegativeOrZero.class, NegativeOrZero::groups);
         if (negativeAnnotation != null) {
             return BigDecimal.ZERO;
         }
@@ -370,11 +411,11 @@ public class JavaxValidationModule implements Module {
      * @see Negative
      */
     protected BigDecimal resolveNumberExclusiveMaximum(MemberScope<?, ?> member) {
-        DecimalMax decimalMaxAnnotation = this.getAnnotationFromFieldOrGetter(member, DecimalMax.class);
+        DecimalMax decimalMaxAnnotation = this.getAnnotationFromFieldOrGetter(member, DecimalMax.class, DecimalMax::groups);
         if (decimalMaxAnnotation != null && !decimalMaxAnnotation.inclusive()) {
             return new BigDecimal(decimalMaxAnnotation.value());
         }
-        Negative negativeAnnotation = this.getAnnotationFromFieldOrGetter(member, Negative.class);
+        Negative negativeAnnotation = this.getAnnotationFromFieldOrGetter(member, Negative.class, Negative::groups);
         if (negativeAnnotation != null) {
             return BigDecimal.ZERO;
         }

--- a/src/test/java/com/github/victools/jsonschema/module/javax/validation/JavaxValidationModuleTest.java
+++ b/src/test/java/com/github/victools/jsonschema/module/javax/validation/JavaxValidationModuleTest.java
@@ -42,6 +42,7 @@ import javax.validation.constraints.PositiveOrZero;
 import javax.validation.constraints.Size;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -173,9 +174,35 @@ public class JavaxValidationModuleTest {
 
     @Test
     @Parameters(method = "parametersForTestNullableCheck")
-    public void testNullableCheckOnField(String fieldName, Boolean expectedResult) throws Exception {
+    public void testNullableCheckOnFieldNoValidationGroup(String fieldName, Boolean expectedResult) throws Exception {
         new JavaxValidationModule().applyToConfigBuilder(this.configBuilder);
 
+        this.testNullableCheckOnField(fieldName, expectedResult);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNullableCheck")
+    public void testNullableCheckOnFieldMatchingValidationGroup(String fieldName, Boolean expectedResult) throws Exception {
+        new JavaxValidationModule()
+                .forValidationGroups(Test.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.testNullableCheckOnField(fieldName, expectedResult);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNullableCheck")
+    @TestCaseName("{method}({0}) [{index}]")
+    public void testNullableCheckOnFieldDifferentValidationGroup(String fieldName, Boolean ignoredResult) throws Exception {
+        new JavaxValidationModule()
+                .forValidationGroups(Object.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        // none of the annotated values are actually expected to be returned
+        this.testNullableCheckOnField(fieldName, null);
+    }
+
+    private void testNullableCheckOnField(String fieldName, Boolean expectedResult) throws Exception {
         ArgumentCaptor<ConfigFunction<FieldScope, Boolean>> captor = ArgumentCaptor.forClass(ConfigFunction.class);
         Mockito.verify(this.fieldConfigPart).withNullableCheck(captor.capture());
         TestType testType = new TestType(TestClassForNullableCheck.class);
@@ -187,9 +214,35 @@ public class JavaxValidationModuleTest {
 
     @Test
     @Parameters(method = "parametersForTestNullableCheck")
-    public void testNullableCheckOnMethod(String fieldName, Boolean expectedResult) throws Exception {
+    public void testNullableCheckOnMethodNoValidationGroup(String fieldName, Boolean expectedResult) throws Exception {
         new JavaxValidationModule().applyToConfigBuilder(this.configBuilder);
 
+        this.testNullableCheckOnMethod(fieldName, expectedResult);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNullableCheck")
+    public void testNullableCheckOnMethodMatchingValidationGroup(String fieldName, Boolean expectedResult) throws Exception {
+        new JavaxValidationModule()
+                .forValidationGroups(Test.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.testNullableCheckOnMethod(fieldName, expectedResult);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNullableCheck")
+    @TestCaseName("{method}({0}) [{index}]")
+    public void testNullableCheckOnMethodDifferentValidationGroup(String fieldName, Boolean ignoredResult) throws Exception {
+        new JavaxValidationModule()
+                .forValidationGroups(Object.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        // none of the annotated values are actually expected to be returned
+        this.testNullableCheckOnMethod(fieldName, null);
+    }
+
+    private void testNullableCheckOnMethod(String fieldName, Boolean expectedResult) throws Exception {
         ArgumentCaptor<ConfigFunction<MethodScope, Boolean>> captor = ArgumentCaptor.forClass(ConfigFunction.class);
         Mockito.verify(this.methodConfigPart).withNullableCheck(captor.capture());
         TestType testType = new TestType(TestClassForNullableCheck.class);
@@ -217,10 +270,38 @@ public class JavaxValidationModuleTest {
     }
 
     @Test
-    @Parameters
-    public void testArrayItemCountResolvers(String fieldName, Integer expectedMinItems, Integer expectedMaxItems) throws Exception {
+    @Parameters(method = "parametersForTestArrayItemCountResolvers")
+    public void testArrayItemCountResolversNoValidationGroup(String fieldName, Integer expectedMinItems, Integer expectedMaxItems) throws Exception {
         new JavaxValidationModule().applyToConfigBuilder(this.configBuilder);
 
+        this.testArrayItemCountResolvers(fieldName, expectedMinItems, expectedMaxItems);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestArrayItemCountResolvers")
+    public void testArrayItemCountResolversMatchingValidationGroup(String fieldName, Integer expectedMinItems, Integer expectedMaxItems)
+            throws Exception {
+        new JavaxValidationModule()
+                .forValidationGroups(Test.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.testArrayItemCountResolvers(fieldName, expectedMinItems, expectedMaxItems);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestArrayItemCountResolvers")
+    @TestCaseName("{method}({0}) [{index}]")
+    public void testArrayItemCountResolversDifferentValidationGroup(String fieldName, Integer ignoredMinItems, Integer ignoredMaxItems)
+            throws Exception {
+        new JavaxValidationModule()
+                .forValidationGroups(Object.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        // none of the annotated values are actually expected to be returned
+        this.testArrayItemCountResolvers(fieldName, null, null);
+    }
+
+    private void testArrayItemCountResolvers(String fieldName, Integer expectedMinItems, Integer expectedMaxItems) throws Exception {
         TestType testType = new TestType(TestClassForArrayItemCount.class);
         FieldScope field = testType.getMemberField(fieldName);
 
@@ -254,10 +335,38 @@ public class JavaxValidationModuleTest {
     }
 
     @Test
-    @Parameters
-    public void testStringLengthResolvers(String fieldName, Integer expectedMinLength, Integer expectedMaxLength) throws Exception {
+    @Parameters(method = "parametersForTestStringLengthResolvers")
+    public void testStringLengthResolversNoValidationGroup(String fieldName, Integer expectedMinLength, Integer expectedMaxLength) throws Exception {
         new JavaxValidationModule().applyToConfigBuilder(this.configBuilder);
 
+        this.testStringLengthResolvers(fieldName, expectedMinLength, expectedMaxLength);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestStringLengthResolvers")
+    public void testStringLengthResolversMatchingValidationGroup(String fieldName, Integer expectedMinLength, Integer expectedMaxLength)
+            throws Exception {
+        new JavaxValidationModule()
+                .forValidationGroups(Test.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.testStringLengthResolvers(fieldName, expectedMinLength, expectedMaxLength);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestStringLengthResolvers")
+    @TestCaseName("{method}({0}) [{index}]")
+    public void testStringLengthResolversDifferentValidationGroup(String fieldName, Integer ignoredMinLength, Integer ignoredMaxLength)
+            throws Exception {
+        new JavaxValidationModule()
+                .forValidationGroups(Object.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        // none of the annotated values are actually expected to be returned
+        this.testStringLengthResolvers(fieldName, null, null);
+    }
+
+    private void testStringLengthResolvers(String fieldName, Integer expectedMinLength, Integer expectedMaxLength) throws Exception {
         TestType testType = new TestType(TestClassForStringProperties.class);
         FieldScope field = testType.getMemberField(fieldName);
 
@@ -295,11 +404,40 @@ public class JavaxValidationModuleTest {
     }
 
     @Test
-    @Parameters
-    public void testStringFormatAndPatternResolvers(String fieldName, JavaxValidationOption[] options, String expectedFormat, String expectedPattern)
-            throws Exception {
+    @Parameters(method = "parametersForTestStringFormatAndPatternResolvers")
+    public void testStringFormatAndPatternResolversNoValidationGroup(String fieldName, JavaxValidationOption[] options,
+            String expectedFormat, String expectedPattern) throws Exception {
         new JavaxValidationModule(options).applyToConfigBuilder(this.configBuilder);
 
+        this.testStringFormatAndPatternResolvers(fieldName, expectedFormat, expectedPattern);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestStringFormatAndPatternResolvers")
+    public void testStringFormatAndPatternResolversMatchingValidationGroup(String fieldName, JavaxValidationOption[] options,
+            String expectedFormat, String expectedPattern) throws Exception {
+        new JavaxValidationModule(options)
+                .forValidationGroups(Test.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.testStringFormatAndPatternResolvers(fieldName, expectedFormat, expectedPattern);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestStringFormatAndPatternResolvers")
+    @TestCaseName("{method}({0}, {1}) [{index}]")
+    public void testStringFormatAndPatternResolversDifferentValidationGroup(String fieldName, JavaxValidationOption[] options,
+            String ignoredFormat, String ignoredPattern) throws Exception {
+        new JavaxValidationModule(options)
+                .forValidationGroups(Object.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        // none of the annotated values are actually expected to be returned
+        this.testStringFormatAndPatternResolvers(fieldName, null, null);
+    }
+
+    private void testStringFormatAndPatternResolvers(String fieldName, String expectedFormat, String expectedPattern)
+            throws Exception {
         TestType testType = new TestType(TestClassForStringProperties.class);
         FieldScope field = testType.getMemberField(fieldName);
 
@@ -337,11 +475,40 @@ public class JavaxValidationModuleTest {
     }
 
     @Test
-    @Parameters
-    public void testNumberMinMaxResolvers(String fieldName, BigDecimal expectedMinInclusive, BigDecimal expectedMinExclusive,
+    @Parameters(method = "parametersForTestNumberMinMaxResolvers")
+    public void testNumberMinMaxResolversNoValidationGroup(String fieldName, BigDecimal expectedMinInclusive, BigDecimal expectedMinExclusive,
             BigDecimal expectedMaxInclusive, BigDecimal expectedMaxExclusive) throws Exception {
         new JavaxValidationModule().applyToConfigBuilder(this.configBuilder);
 
+        this.testNumberMinMaxResolvers(fieldName, expectedMinInclusive, expectedMinExclusive, expectedMaxInclusive, expectedMaxExclusive);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNumberMinMaxResolvers")
+    public void testNumberMinMaxResolversMatchingValidationGroup(String fieldName, BigDecimal expectedMinInclusive, BigDecimal expectedMinExclusive,
+            BigDecimal expectedMaxInclusive, BigDecimal expectedMaxExclusive) throws Exception {
+        new JavaxValidationModule()
+                .forValidationGroups(Test.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.testNumberMinMaxResolvers(fieldName, expectedMinInclusive, expectedMinExclusive, expectedMaxInclusive, expectedMaxExclusive);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNumberMinMaxResolvers")
+    @TestCaseName("{method}({0}) [{index}]")
+    public void testNumberMinMaxResolversDifferentValidationGroup(String fieldName, BigDecimal ignoredMinInclusive, BigDecimal ignoredMinExclusive,
+            BigDecimal ignoredMaxInclusive, BigDecimal ignoredMaxExclusive) throws Exception {
+        new JavaxValidationModule()
+                .forValidationGroups(Object.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        // none of the annotated values are actually expected to be returned
+        this.testNumberMinMaxResolvers(fieldName, null, null, null, null);
+    }
+
+    private void testNumberMinMaxResolvers(String fieldName, BigDecimal expectedMinInclusive, BigDecimal expectedMinExclusive,
+            BigDecimal expectedMaxInclusive, BigDecimal expectedMaxExclusive) {
         TestType testType = new TestType(TestClassForNumberMinMax.class);
         FieldScope field = testType.getMemberField(fieldName);
 
@@ -366,19 +533,60 @@ public class JavaxValidationModuleTest {
         Assert.assertEquals(expectedMaxExclusive, maxExclusive);
     }
 
+    public Object[] parametersForTestValidationGroupSetting() {
+        return new Object[][]{
+            {"skippedConfiguringGroups", "fieldWithoutValidationGroup", Boolean.TRUE, null},
+            {"skippedConfiguringGroups", "fieldWithSingleValidationGroup", Boolean.TRUE, null},
+            {"skippedConfiguringGroups", "fieldWithMultipleValidationGroups", Boolean.TRUE, null},
+            {"noConfiguredGroups", "fieldWithoutValidationGroup", Boolean.TRUE, new Class<?>[0]},
+            {"noConfiguredGroups", "fieldWithSingleValidationGroup", null, new Class<?>[0]},
+            {"noConfiguredGroups", "fieldWithMultipleValidationGroups", null, new Class<?>[0]},
+            {"singleConfiguredGroup", "fieldWithoutValidationGroup", Boolean.TRUE, new Class<?>[]{Test.class}},
+            {"singleConfiguredMatchingGroup", "fieldWithSingleValidationGroup", Boolean.TRUE, new Class<?>[]{Test.class}},
+            {"singleConfiguredMatchingGroup", "fieldWithMultipleValidationGroups", Boolean.TRUE, new Class<?>[]{Test.class}},
+            {"singleConfiguredDifferentGroup", "fieldWithSingleValidationGroup", null, new Class<?>[]{Object.class}},
+            {"singleConfiguredDifferentGroup", "fieldWithMultipleValidationGroups", null, new Class<?>[]{Object.class}},
+            {"multipleConfiguredGroups", "fieldWithoutValidationGroup", Boolean.TRUE, new Class<?>[]{Test.class, Object.class}},
+            {"multipleConfiguredGroupsSingleMatch", "fieldWithSingleValidationGroup", Boolean.TRUE, new Class<?>[]{Test.class, Object.class}},
+            {"multipleConfiguredGroupsSingleMatch", "fieldWithMultipleValidationGroups", Boolean.TRUE, new Class<?>[]{Test.class, Object.class}},
+            {"multipleConfiguredGroupsMultipleMatches", "fieldWithMultipleValidationGroups", Boolean.TRUE, new Class<?>[]{Test.class, Assert.class}},
+            {"multipleConfiguredGroupsNoMatch", "fieldWithSingleValidationGroup", null, new Class<?>[]{Integer.class, Double.class}},
+            {"multipleConfiguredGroupsNoMatch", "fieldWithMultipleValidationGroups", null, new Class<?>[]{Integer.class, Double.class}}
+        };
+    }
+
+    @Test
+    @Parameters
+    @TestCaseName("{method}({0}, {1}, {2}) [{index}]")
+    public void testValidationGroupSetting(String testCase, String fieldName, Boolean expectedResult, Class<?>[] validationGroups) {
+        JavaxValidationModule module = new JavaxValidationModule();
+        if (validationGroups != null) {
+            module.forValidationGroups(validationGroups);
+        }
+        module.applyToConfigBuilder(this.configBuilder);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, Boolean>> captor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withNullableCheck(captor.capture());
+        TestType testType = new TestType(TestClassForValidationGroups.class);
+        FieldScope field = testType.getMemberField(fieldName);
+
+        Boolean result = captor.getValue().apply(field);
+        Assert.assertEquals(expectedResult, result);
+    }
+
     private static class TestClassForNullableCheck {
 
         Integer unannotatedField;
-        @NotNull
+        @NotNull(groups = Test.class)
         Double notNullNumber;
         Double notNullOnGetterNumber;
-        @NotEmpty
+        @NotEmpty(groups = Test.class)
         List<Object> notEmptyList;
         List<Object> notEmptyOnGetterList;
-        @NotBlank
+        @NotBlank(groups = Test.class)
         String notBlankString;
         String notBlankOnGetterString;
-        @Null
+        @Null(groups = Test.class)
         Object nullField;
         Object nullGetter;
 
@@ -390,7 +598,7 @@ public class JavaxValidationModuleTest {
             return this.notNullNumber;
         }
 
-        @NotNull
+        @NotNull(groups = Test.class)
         public Double getNotNullOnGetterNumber() {
             return this.notNullOnGetterNumber;
         }
@@ -399,7 +607,7 @@ public class JavaxValidationModuleTest {
             return this.notEmptyList;
         }
 
-        @NotEmpty
+        @NotEmpty(groups = Test.class)
         public List<Object> getNotEmptyOnGetterList() {
             return this.notEmptyOnGetterList;
         }
@@ -408,7 +616,7 @@ public class JavaxValidationModuleTest {
             return this.notBlankString;
         }
 
-        @NotBlank
+        @NotBlank(groups = Test.class)
         public String getNotBlankOnGetterString() {
             return this.notBlankOnGetterString;
         }
@@ -417,7 +625,7 @@ public class JavaxValidationModuleTest {
             return this.nullField;
         }
 
-        @Null
+        @Null(groups = Test.class)
         public Object getNullGetter() {
             return this.nullGetter;
         }
@@ -426,45 +634,45 @@ public class JavaxValidationModuleTest {
     private static class TestClassForArrayItemCount {
 
         String[] unannotatedArray;
-        @Size(min = 10, max = 20)
+        @Size(min = 10, max = 20, groups = Test.class)
         String sizeTenToTwentyString;
         String sizeTenToTwentyOnGetterString;
-        @Size(min = 5)
+        @Size(min = 5, groups = Test.class)
         int[] minSizeFiveArray;
         int[] minSizeFiveOnGetterArray;
-        @Size(max = 50)
+        @Size(max = 50, groups = Test.class)
         long[] maxSizeFiftyArray;
         long[] maxSizeFiftyOnGetterArray;
-        @Size(min = 10, max = 20)
+        @Size(min = 10, max = 20, groups = Test.class)
         Set<Boolean> sizeTenToTwentySet;
         Set<Boolean> sizeTenToTwentyOnGetterSet;
-        @NotEmpty
-        @Size(max = 100)
+        @NotEmpty(groups = Test.class)
+        @Size(max = 100, groups = Test.class)
         List<Double> nonEmptyMaxSizeHundredList;
         List<Double> nonEmptyMaxSizeHundredOnGetterList;
 
-        @Size(min = 10, max = 20)
+        @Size(min = 10, max = 20, groups = Test.class)
         public String getSizeTenToTwentyString() {
             return this.sizeTenToTwentyString;
         }
 
-        @Size(min = 5)
+        @Size(min = 5, groups = Test.class)
         public int[] getMinSizeFiveOnGetterArray() {
             return this.minSizeFiveOnGetterArray;
         }
 
-        @Size(max = 50)
+        @Size(max = 50, groups = Test.class)
         public long[] getMaxSizeFiftyOnGetterArray() {
             return this.maxSizeFiftyOnGetterArray;
         }
 
-        @Size(min = 10, max = 20)
+        @Size(min = 10, max = 20, groups = Test.class)
         public Set<Boolean> getSizeTenToTwentyOnGetterSet() {
             return this.sizeTenToTwentyOnGetterSet;
         }
 
-        @NotEmpty
-        @Size(max = 100)
+        @NotEmpty(groups = Test.class)
+        @Size(max = 100, groups = Test.class)
         public List<Double> getNonEmptyMaxSizeHundredOnGetterList() {
             return this.nonEmptyMaxSizeHundredOnGetterList;
         }
@@ -473,63 +681,63 @@ public class JavaxValidationModuleTest {
     private static class TestClassForStringProperties {
 
         String unannotatedString;
-        @Size(min = 10, max = 20)
-        @Email
-        @Pattern(regexp = ".*")
+        @Size(min = 10, max = 20, groups = Test.class)
+        @Email(groups = Test.class)
+        @Pattern(regexp = ".*", groups = Test.class)
         int[] sizeTenToTwentyArray;
         int[] sizeTenToTwentyOnGetterArray;
-        @Size(min = 5)
-        @Pattern(regexp = "^\\d+$")
+        @Size(min = 5, groups = Test.class)
+        @Pattern(regexp = "^\\d+$", groups = Test.class)
         CharSequence minSizeFiveSequence;
         CharSequence minSizeFiveOnGetterSequence;
-        @Size(max = 50)
+        @Size(max = 50, groups = Test.class)
         String maxSizeFiftyString;
         String maxSizeFiftyOnGetterString;
-        @Size(min = 10, max = 20)
+        @Size(min = 10, max = 20, groups = Test.class)
         String sizeTenToTwentyString;
         String sizeTenToTwentyOnGetterString;
-        @NotEmpty
-        @Size(max = 100)
-        @Email
+        @NotEmpty(groups = Test.class)
+        @Size(max = 100, groups = Test.class)
+        @Email(groups = Test.class)
         String nonEmptyMaxSizeHundredString;
         String nonEmptyMaxSizeHundredOnGetterString;
-        @NotBlank
-        @Email(regexp = "^.+your-company\\.com$")
+        @NotBlank(groups = Test.class)
+        @Email(regexp = "^.+your-company\\.com$", groups = Test.class)
         String nonBlankString;
         String nonBlankOnGetterString;
 
-        @Size(min = 10, max = 20)
-        @Email
-        @Pattern(regexp = ".*")
+        @Size(min = 10, max = 20, groups = Test.class)
+        @Email(groups = Test.class)
+        @Pattern(regexp = ".*", groups = Test.class)
         public int[] getSizeTenToTwentyOnGetterArray() {
             return this.sizeTenToTwentyOnGetterArray;
         }
 
-        @Size(min = 5)
-        @Pattern(regexp = "^\\d+$")
+        @Size(min = 5, groups = Test.class)
+        @Pattern(regexp = "^\\d+$", groups = Test.class)
         public CharSequence getMinSizeFiveOnGetterSequence() {
             return this.minSizeFiveOnGetterSequence;
         }
 
-        @Size(max = 50)
+        @Size(max = 50, groups = Test.class)
         public String getMaxSizeFiftyOnGetterString() {
             return this.maxSizeFiftyOnGetterString;
         }
 
-        @Size(min = 10, max = 20)
+        @Size(min = 10, max = 20, groups = Test.class)
         public String getSizeTenToTwentyOnGetterString() {
             return this.sizeTenToTwentyOnGetterString;
         }
 
-        @NotEmpty
-        @Size(max = 100)
-        @Email
+        @NotEmpty(groups = Test.class)
+        @Size(max = 100, groups = Test.class)
+        @Email(groups = Test.class)
         public String getNonEmptyMaxSizeHundredOnGetterString() {
             return this.nonEmptyMaxSizeHundredOnGetterString;
         }
 
-        @NotBlank
-        @Email(regexp = "^.+your-company\\.com$")
+        @NotBlank(groups = Test.class)
+        @Email(regexp = "^.+your-company\\.com$", groups = Test.class)
         public String getNonBlankOnGetterString() {
             return this.nonBlankOnGetterString;
         }
@@ -538,73 +746,83 @@ public class JavaxValidationModuleTest {
     private static class TestClassForNumberMinMax {
 
         int unannotatedInt;
-        @Min(-100L)
+        @Min(value = -100L, groups = Test.class)
         long minMinusHundredLong;
         long minMinusHundredOnGetterLong;
-        @Max(50)
+        @Max(value = 50, groups = Test.class)
         short maxFiftyShort;
         short maxFiftyOnGetterShort;
-        @DecimalMin("10.1")
-        @DecimalMax("20.2")
+        @DecimalMin(value = "10.1", groups = Test.class)
+        @DecimalMax(value = "20.2", groups = Test.class)
         Integer tenToTwentyInclusiveInteger;
         Integer tenToTwentyInclusiveOnGetterInteger;
-        @DecimalMin(value = "10.1", inclusive = false)
-        @DecimalMax(value = "20.2", inclusive = false)
+        @DecimalMin(value = "10.1", inclusive = false, groups = Test.class)
+        @DecimalMax(value = "20.2", inclusive = false, groups = Test.class)
         Integer tenToTwentyExclusiveInteger;
         Integer tenToTwentyExclusiveOnGetterInteger;
-        @Positive
+        @Positive(groups = Test.class)
         byte positiveByte;
         byte positiveOnGetterByte;
-        @PositiveOrZero
+        @PositiveOrZero(groups = Test.class)
         BigInteger positiveOrZeroBigInteger;
         BigInteger positiveOrZeroOnGetterBigInteger;
-        @Negative
+        @Negative(groups = Test.class)
         BigDecimal negativeDecimal;
         BigDecimal negativeOnGetterDecimal;
-        @NegativeOrZero
+        @NegativeOrZero(groups = Test.class)
         Long negativeOrZeroLong;
         Long negativeOrZeroOnGetterLong;
 
-        @Min(-100L)
+        @Min(value = -100L, groups = Test.class)
         public long getMinMinusHundredOnGetterLong() {
             return minMinusHundredOnGetterLong;
         }
 
-        @Max(50)
+        @Max(value = 50, groups = Test.class)
         public short getMaxFiftyOnGetterShort() {
             return maxFiftyOnGetterShort;
         }
 
-        @DecimalMin("10.1")
-        @DecimalMax("20.2")
+        @DecimalMin(value = "10.1", groups = Test.class)
+        @DecimalMax(value = "20.2", groups = Test.class)
         public Integer getTenToTwentyInclusiveOnGetterInteger() {
             return tenToTwentyInclusiveOnGetterInteger;
         }
 
-        @DecimalMin(value = "10.1", inclusive = false)
-        @DecimalMax(value = "20.2", inclusive = false)
+        @DecimalMin(value = "10.1", inclusive = false, groups = Test.class)
+        @DecimalMax(value = "20.2", inclusive = false, groups = Test.class)
         public Integer getTenToTwentyExclusiveOnGetterInteger() {
             return tenToTwentyExclusiveOnGetterInteger;
         }
 
-        @Positive
+        @Positive(groups = Test.class)
         public byte getPositiveOnGetterByte() {
             return positiveOnGetterByte;
         }
 
-        @PositiveOrZero
+        @PositiveOrZero(groups = Test.class)
         public BigInteger getPositiveOrZeroOnGetterBigInteger() {
             return positiveOrZeroOnGetterBigInteger;
         }
 
-        @Negative
+        @Negative(groups = Test.class)
         public BigDecimal getNegativeOnGetterDecimal() {
             return negativeOnGetterDecimal;
         }
 
-        @NegativeOrZero
+        @NegativeOrZero(groups = Test.class)
         public Long getNegativeOrZeroOnGetterLong() {
             return negativeOrZeroOnGetterLong;
         }
+    }
+
+    private static class TestClassForValidationGroups {
+
+        @Null
+        String fieldWithoutValidationGroup;
+        @Null(groups = Test.class)
+        String fieldWithSingleValidationGroup;
+        @Null(groups = {Test.class, Assert.class})
+        String fieldWithMultipleValidationGroups;
     }
 }


### PR DESCRIPTION
Changes requested by @hleb-albau in https://github.com/victools/jsonschema-generator/issues/7

The `javax.validation.constraints` annotations all cater for a `groups` property (a list of classes) to be defined, which determine the scope in which a particular validation is applicable.
The desired `groups` can now be specified by calling the new `forValidationGroups(Class<?>...)` method on the `JavaxValidationModule` instance, which returns the same module instance to allow for simple chaining, e.g.
```java
SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder()
        .with(new JavaxValidationModule().forValidationGroups(Default.class));
```

The changes apply to all currently supported annotations.
An annotation is deemed applicable in one of the following three cases:
1. Validation groups are specifically ignored (i.e. `forValidationGroups()` was never called or with null as only parameter)
2. No validation groups are specified on the annotation.
3. Some validation group(s) are specified on the annotation and at least one of them was provided via` forValidationGroups()`.