### PR TITLE
chore(package): bump generator version to 4.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <version.generator>4.3.0</version.generator>
+        <version.generator>4.4.0</version.generator>
 
         <version.javax.validation>2.0.1.Final</version.javax.validation>
 


### PR DESCRIPTION
Actually no need for re-build here, but for consistency's sake as per other standard modules – victools/jsonschema-generator#36.